### PR TITLE
MHPY-13 return second response after token refresh

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
 from enum import Enum
 from typing import Optional
 
@@ -101,6 +100,8 @@ class MediaHavenClient:
                 # Refresh token invalid / revoked
                 # Depending on grant, different action is needed
                 raise RefreshTokenError
+            else:
+                return response
         except RequestException:
             # TODO: Log/raise?
             pass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@ black==22.1.0
 Mypy==0.940
 # Testing
 pytest==7.2.0
-responses==0.13.2
+responses==0.22.0


### PR DESCRIPTION
If a call is executed after the access token is expired, a new token is requested with the refresh token. The same call is then executed but with the new access token. However, the response of that second call didn't get returned.

Bump responses to the latest version and use shorthand version to add responses.