### PR TITLE
Reraise RequestException

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from requests import RequestException
 from requests.models import Response
-
 from oauthlib.oauth2.rfc6749.errors import (
     TokenExpiredError,
     InvalidGrantError,
@@ -80,6 +79,7 @@ class MediaHavenClient:
         Raises:
             NoTokenError: If a token has not yet been requested.
             RefreshTokenError: If an error occurred when refreshing the token.
+            requests.RequestException: Reraise if a RequestException happen.
         """
         # Get a session with a valid auth
         try:
@@ -103,8 +103,7 @@ class MediaHavenClient:
             else:
                 return response
         except RequestException:
-            # TODO: Log/raise?
-            pass
+            raise
         else:
             return response
 

--- a/mediahaven/oauth2.py
+++ b/mediahaven/oauth2.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import logging
 from abc import ABC, abstractmethod
 from urllib.parse import urljoin
 
@@ -11,8 +10,6 @@ from oauthlib.oauth2.rfc6749.errors import (
     InvalidClientError,
 )
 from requests_oauthlib import OAuth2Session
-
-logging.basicConfig(level=logging.INFO)
 
 
 class RequestTokenError(Exception):


### PR DESCRIPTION
The RequestException thrown by the requests library was caught, with no clear action. This resulted in failure down the line as there was no response object instantiated. Reraise that error so that the using application can catch it and move on.

Also, remove logging from oauth2.py:
 - Not clear what the reasoning is.
 - If needed, should be on another level than oauth2.py.