### PR TITLE
MHPY-17 Return true for successful POST request

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -230,7 +230,7 @@ class MediaHavenClient:
 
     def _post(
         self, resource_path: str, json: dict = None, xml: str = None, **form_data
-    ) -> Optional[dict]:
+    ) -> Union[dict, bool]:
         """Execute a POST request.
 
         For some POST requests, MediaHaven allows JSON, XML or multipart/form-data.
@@ -246,9 +246,10 @@ class MediaHavenClient:
         Returns:
             - The requests response as a dict if the status code is in the successful
                 2xx range and the response contains a body.
-            - None if the status code is:
-              - In the successful 2xx range but no response body.
-              - Not in the successful 2xx range but also not in error range (4xx-5xx).
+            - True if the status code is in the successful 2xx range but no response
+                body.
+            - False if the status code is not in the successful 2xx range but also
+                not in error range (4xx-5xx).
 
         Raises:
             MediaHavenException: If the response has a status >= 400.
@@ -288,9 +289,9 @@ class MediaHavenClient:
             try:
                 return response.json()
             except JSONDecodeError:
-                return None
+                return True
 
-        return None
+        return False
 
     def _put(
         self, resource_path: str, json: dict = None, xml: str = None, **form_data

--- a/mediahaven/resources/base_resource.py
+++ b/mediahaven/resources/base_resource.py
@@ -146,7 +146,7 @@ class MediaHavenPageObject(ABC):
         Args:
             response: The HTTP response.
             resource: The resource that executed the initial request.
-            **query_params: The optional query paramaters.
+            **query_params: The optional query parameters.
         """
         self._resource: BaseResource = resource
         self._query_params: dict = query_params

--- a/mediahaven/resources/field_definitions.py
+++ b/mediahaven/resources/field_definitions.py
@@ -45,7 +45,7 @@ class FieldDefinitions(BaseResource):
 
         Args:
             accept_format: The "Accept" request header.
-            **query_params: The optional query paramaters:
+            **query_params: The optional query parameters:
                 query_params["startIndex"]: Used for pagination of search results,
                     search results will be returned starting from this index.
                 query_params["nrOfResults"]: the number of results that will be returned.

--- a/mediahaven/resources/records.py
+++ b/mediahaven/resources/records.py
@@ -58,7 +58,7 @@ class Records(BaseResource):
 
         Args:
             accept_format: The "Accept" request header.
-            **query_params: The optional query paramaters:
+            **query_params: The optional query parameters:
                 query_params["q"]: Free text search string.
                 query_params["startIndex"]: Used for pagination of search results,
                     search results will be returned starting from this index.

--- a/tests/test_mediahaven.py
+++ b/tests/test_mediahaven.py
@@ -217,7 +217,7 @@ class TestMediahaven:
         resp = mh_client._post(resource_path, json=payload)
 
         # Assert
-        assert resp is None
+        assert resp is True
         assert len(responses.calls) == 1
         assert responses.calls[0].request.method == "POST"
         assert responses.calls[0].request.headers["Content-Type"] == "application/json"
@@ -282,7 +282,7 @@ class TestMediahaven:
         resp = mh_client._post(resource_path, xml=payload)
 
         # Assert
-        assert resp is None
+        assert resp is True
         assert len(responses.calls) == 1
         assert responses.calls[0].request.method == "POST"
         assert responses.calls[0].request.headers["Content-Type"] == "application/xml"
@@ -342,7 +342,7 @@ class TestMediahaven:
         resp = mh_client._post(resource_path, **payload)
 
         # Assert
-        assert resp is None
+        assert resp is True
         assert len(responses.calls) == 1
         assert responses.calls[0].request.method == "POST"
         assert (


### PR DESCRIPTION
The POST request returned None when the request is successful but contains no body e.g. response with status 204. It should return True in that case.