### PR TITLE
MHPY-18 Fix updating metadata via form-data

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -36,6 +36,11 @@ class AcceptFormat(Enum):
     UNKNOWN = ""
 
 
+class ContentType(Enum):
+    JSON = "application/json"
+    XML = "application/xml"
+
+
 DEFAULT_ACCEPT_FORMAT = AcceptFormat.JSON
 
 
@@ -229,7 +234,12 @@ class MediaHavenClient:
         return False
 
     def _post(
-        self, resource_path: str, json: dict = None, xml: str = None, **form_data
+        self,
+        resource_path: str,
+        json: dict = None,
+        xml: str = None,
+        files: dict = None,
+        **form_data,
     ) -> Union[dict, bool]:
         """Execute a POST request.
 
@@ -241,7 +251,8 @@ class MediaHavenClient:
             resource_path: The path of the resource.
             json: The JSON payload.
             xml: The XML payload.
-            **form_data: The payload as multipart/form-data.
+            files: The files to upload. This is only used if form-data is used.
+            **form_data: The form data.
 
         Returns:
             - The requests response as a dict if the status code is in the successful
@@ -276,9 +287,10 @@ class MediaHavenClient:
                 **dict(method="POST", url=resource_url, headers=headers, data=xml)
             )
         else:
-            # Execute the request - Multipart/form-data
+            # Execute the request - Form
+            files = files if files else {}
             response = self._execute_request(
-                **dict(method="POST", url=resource_url, files=form_data)
+                **dict(method="POST", url=resource_url, files=files, data=form_data)
             )
 
         # Raise appropriate exception if HTTPError occurred

--- a/mediahaven/resources/records.py
+++ b/mediahaven/resources/records.py
@@ -109,7 +109,7 @@ class Records(BaseResource):
         specifies the content-type of the former.
 
         Args:
-            record_id: The ID of the record to remove.
+            record_id: The ID of the record to update.
                 It can be either a MediaObjectId, FragmentId or RecordId.
             json: The JSON payload.
             xml: The XML payload.

--- a/mediahaven/resources/records.py
+++ b/mediahaven/resources/records.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from typing import Any, Dict
-from mediahaven.mediahaven import DEFAULT_ACCEPT_FORMAT
+from mediahaven.mediahaven import ContentType, DEFAULT_ACCEPT_FORMAT
 from mediahaven.resources.base_resource import (
     BaseResource,
     MediaHavenPageObject,
@@ -103,18 +103,52 @@ class Records(BaseResource):
     def update(self, record_id: str, json: dict = None, xml: str = None, **form_data):
         """Update a record.
 
+        The payload is a MediaHaven record update object. The object can be in the
+        form of JSON, XML or form-data. In the case of passing form-data, the
+        parameters metadata and content_type_metadata are mandatory. The latter
+        specifies the content-type of the former.
+
         Args:
             record_id: The ID of the record to remove.
                 It can be either a MediaObjectId, FragmentId or RecordId.
             json: The JSON payload.
             xml: The XML payload.
-            **form_data: The payload as multipart/form-data.
+            **form_data: The payload as form-data.
+
+        Raises:
+            ValueError: In the case that form_data is passed, if:
+              - The parameter 'metadata' is not passed;
+              - The parameter 'metadata_content_type' is not passed;
+              - The parameter 'metadata_content_type' contains a different value
+                  than "application/json" or "application/xml".
         """
+
+        files = {}
+        if form_data:
+            try:
+                metadata = form_data.pop("metadata")
+            except KeyError:
+                raise ValueError("The form data needs to contain a key 'metadata'")
+            try:
+                metadata_content_type = form_data.pop("metadata_content_type")
+            except KeyError:
+                raise ValueError(
+                    "The form data needs to contain a key 'metadata_content_type' which specifies the content-type of the metadata"
+                )
+            if metadata_content_type not in (
+                ContentType.JSON.value,
+                ContentType.XML.value,
+            ):
+                raise ValueError(
+                    f"The metadata_content_type' should be '{ContentType.JSON.value}' or '{ContentType.XML.value}'"
+                )
+            files = {"metadata": ("metadata", metadata, metadata_content_type)}
 
         return self.mh_client._post(
             self._construct_path(record_id),
             json=json,
             xml=xml,
+            files=files,
             **form_data,
         )
 

--- a/tests/test_mediahaven.py
+++ b/tests/test_mediahaven.py
@@ -9,7 +9,12 @@ from oauthlib.oauth2.rfc6749.errors import (
 from requests import RequestException
 from urllib.parse import urljoin
 
-from mediahaven.mediahaven import AcceptFormat, MediaHavenClient, MediaHavenException
+from mediahaven.mediahaven import (
+    AcceptFormat,
+    ContentType,
+    MediaHavenClient,
+    MediaHavenException,
+)
 
 
 class TestMediahaven:
@@ -314,7 +319,11 @@ class TestMediahaven:
         responses.post(url, status=status, body=json.dumps(response))
 
         # Act
-        resp = mh_client._post(resource_path, **payload)
+        resp = mh_client._post(
+            resource_path,
+            files={"metadata": ("metadata", "<metadata/>", ContentType.XML.value)},
+            **payload,
+        )
 
         # Assert
         assert resp == response
@@ -339,7 +348,11 @@ class TestMediahaven:
         responses.post(url, status=204)
 
         # Act
-        resp = mh_client._post(resource_path, **payload)
+        resp = mh_client._post(
+            resource_path,
+            files={"metadata": ("metadata", "<metadata/>", ContentType.XML.value)},
+            **payload,
+        )
 
         # Assert
         assert resp is True


### PR DESCRIPTION
The metadata itself has to be passed as a file, with its content-type explicitly defined. By passing it as a file, the content-type of the HTTP request becomes a multipart/form-data.

Expand the _post method to allow for uploading files.