### PR TITLE
MHPY-19 Add some mocks for testing-purposes

### DIFF
--- a/mediahaven/mocks/base_resource.py
+++ b/mediahaven/mocks/base_resource.py
@@ -1,0 +1,42 @@
+import json
+from types import SimpleNamespace
+from typing import List
+
+from mediahaven.resources.base_resource import (
+    MediaHavenPageObjectJSON,
+    MediaHavenSingleObjectJSON,
+)
+
+
+class MediaHavenSingleObjectJSONMock(MediaHavenSingleObjectJSON):
+    def __init__(self, data: dict):
+        self._single_result: SimpleNamespace = json.loads(
+            json.dumps(data), object_hook=lambda d: SimpleNamespace(**d)
+        )
+
+
+class MediaHavenPageObjectJSONMock(MediaHavenPageObjectJSON):
+    def __init__(
+        self,
+        results: List[dict],
+        nr_of_results: int = 1,
+        start_index: int = 0,
+        total_nr_of_results: int = 1,
+    ):
+        paged_dict = {
+            "NrOfResults": nr_of_results,
+            "StartIndex": start_index,
+            "TotalNrOfResults": total_nr_of_results,
+            "Results": results,
+        }
+        self._page_result: SimpleNamespace = json.loads(
+            json.dumps(paged_dict), object_hook=lambda d: SimpleNamespace(**d)
+        )
+
+        self._total_nr_of_results = total_nr_of_results
+        self._nr_of_results = nr_of_results
+        self._start_index = start_index
+
+        self._has_more = self.total_nr_of_results > (
+            self.nr_of_results + self.start_index
+        )

--- a/tests/mocks/test_base_resource.py
+++ b/tests/mocks/test_base_resource.py
@@ -1,0 +1,21 @@
+from mediahaven.mocks.base_resource import (
+    MediaHavenPageObjectJSONMock,
+    MediaHavenSingleObjectJSONMock,
+)
+
+
+def test_media_haven_single_object_json_mock():
+    data = {"Dynamic": {"field": "value"}}
+    single_object_mock = MediaHavenSingleObjectJSONMock(data)
+    assert single_object_mock.Dynamic.field == "value"
+
+
+def test_media_haven_page_object_json_mock():
+    data = [{"Dynamic": {"field": "value"}}]
+    page_object_mock = MediaHavenPageObjectJSONMock(
+        data, nr_of_results=5, total_nr_of_results=10, start_index=3
+    )
+    assert page_object_mock[0].Dynamic.field == "value"
+    assert page_object_mock.nr_of_results == 5
+    assert page_object_mock.total_nr_of_results == 10
+    assert page_object_mock.start_index == 3


### PR DESCRIPTION
Add `MediaHavenSingleObjectJSONMock` and `MediaHavenPageObjectJSONMock`. These mocks can be used in external applications making use of the library to simplify the process of writing tests.