### PR TITLE
MHPY-20 Allow zero start and end frames

### DIFF
--- a/mediahaven/resources/records.py
+++ b/mediahaven/resources/records.py
@@ -204,14 +204,16 @@ class Records(BaseResource):
         }
 
         # Add the timecodes or frames
-        if (start_time_code or end_time_code) and (start_frames or end_frames):
+        if (start_time_code or end_time_code) and (
+            start_frames is not None or end_frames is not None
+        ):
             raise ValueError(
                 "Provide either a combination of start_time_code and end_time_code or start_frames and end_frames."
             )
         elif start_time_code and end_time_code:
             json["Fragment"]["FragmentStartTimeCode"] = start_time_code
             json["Fragment"]["FragmentEndTimeCode"] = end_time_code
-        elif start_frames and end_frames:
+        elif start_frames is not None and end_frames is not None:
             json["Fragment"]["FragmentStartFrames"] = start_frames
             json["Fragment"]["FragmentEndFrames"] = end_frames
         else:

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -236,12 +236,13 @@ class TestRecords:
             },
         )
 
-    def test_create_fragment_frames(self, records: Records):
+    @pytest.mark.parametrize("start_frames,end_frames", [(5, 10), (0, 0)])
+    def test_create_fragment_frames(
+        self, start_frames: int, end_frames: int, records: Records
+    ):
         # Arrange
         record_id = "1"
         title = "Title"
-        start_frames = 5
-        end_frames = 10
         # Act
         resp = records.create_fragment(
             record_id, title, start_frames=start_frames, end_frames=end_frames
@@ -257,8 +258,8 @@ class TestRecords:
                 "Publish": True,
                 "Fragment": {
                     "ParentRecordId": "1",
-                    "FragmentStartFrames": 5,
-                    "FragmentEndFrames": 10,
+                    "FragmentStartFrames": start_frames,
+                    "FragmentEndFrames": end_frames,
                 },
             },
         )


### PR DESCRIPTION
It should be possible to fill in zero frames. In this context the truthy check incorrectly labels zero frames as false and thus not accepting the zero value. Explicitly check if the frames are not None instead.