### PR TITLE
MHPY-23 Retry a 429 response

### DIFF
--- a/mediahaven/retry.py
+++ b/mediahaven/retry.py
@@ -1,0 +1,52 @@
+import functools
+import time
+
+
+class RetryException(Exception):
+    """Exception raised when an action needs to be retried
+    in combination with retry_exponential decorator"""
+
+    pass
+
+
+class TooManyRetriesException(Exception):
+    """Exception raised when all the tries are exhausted"""
+
+    pass
+
+
+DELAY = 1
+BACKOFF = 2
+NUMBER_OF_TRIES = 10
+
+
+def retry_exponential(
+    exceptions: list[BaseException],
+    delay_seconds: int = DELAY,
+    backoff: int = BACKOFF,
+    number_of_tries: int = NUMBER_OF_TRIES,
+):
+    """A decorator allowing for a function to be retried via an exponential backoff
+
+    Raises:
+     - TooManyRetriesException: When all the (re)tries are exhausted.
+    """
+
+    def decorator_retry(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            number_of_tries_over = number_of_tries
+            delay = delay_seconds
+            while number_of_tries_over:
+                number_of_tries_over -= 1
+                try:
+                    return func(self, *args, **kwargs)
+                except exceptions as error:
+                    # Todo: log
+                    time.sleep(delay)
+                    delay *= backoff
+            raise TooManyRetriesException(f"Too many retries: {number_of_tries}")
+
+        return wrapper
+
+    return decorator_retry

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+from mediahaven.retry import (
+    retry_exponential,
+    RetryException,
+    TooManyRetriesException,
+    NUMBER_OF_TRIES,
+    DELAY,
+    BACKOFF,
+)
+import pytest
+
+
+@patch("time.sleep")
+def test_retry_defaults(time_sleep_mock):
+    function_mock = MagicMock()
+    function_mock.side_effect = RetryException
+
+    @retry_exponential((RetryException))
+    def func(self):
+        function_mock()
+
+    # Execute the decorated method
+    with pytest.raises(TooManyRetriesException):
+        func(MagicMock())
+
+    # Test if function was executed multiple times
+    assert function_mock.call_count == NUMBER_OF_TRIES
+
+    # Test if time.sleep was executed multiple times
+    assert time_sleep_mock.call_count == NUMBER_OF_TRIES
+
+    # Test exponential backoff
+    assert time_sleep_mock.call_args_list[0][0][0] == DELAY
+    for i in range(1, NUMBER_OF_TRIES):
+        prev_val = time_sleep_mock.call_args_list[i - 1][0][0]
+        assert time_sleep_mock.call_args_list[i][0][0] == prev_val * BACKOFF
+
+
+@patch("time.sleep")
+def test_retry(time_sleep_mock):
+    function_mock = MagicMock()
+    function_mock.side_effect = RetryException
+
+    @retry_exponential((RetryException), 2, 4, 5)
+    def func(self):
+        function_mock()
+
+    # Execute the decorated method
+    with pytest.raises(TooManyRetriesException):
+        func(MagicMock())
+
+    # Test if function was executed multiple times
+    assert function_mock.call_count == 5
+
+    # Test if time.sleep was executed multiple times
+    assert time_sleep_mock.call_count == 5
+
+    # Test exponential backoff
+    assert time_sleep_mock.call_args_list[0][0][0] == 2
+    for i in range(1, 5):
+        prev_val = time_sleep_mock.call_args_list[i - 1][0][0]
+        assert time_sleep_mock.call_args_list[i][0][0] == prev_val * 4


### PR DESCRIPTION
Add a boolean to the MediaHavenClient indicating that every executed request should be retried via an exponential backoff if the request hits a rate limit. This means that the response has the status code 429.