### PR TITLE
MHPY-24 Add upload-file-via-URL functionality

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -267,7 +267,7 @@ class MediaHavenClient:
             ValueError: If multiple payload values are passed (json, xml or form_data).
         """
         # Check if only one payload value is passed
-        if bool(json) + bool(xml) + bool(form_data) != 1:
+        if bool(json) + bool(xml) + (bool(files) or bool(form_data)) != 1:
             raise ValueError(
                 "Only one payload value is allowed (json, xml or form_data)"
             )
@@ -288,9 +288,11 @@ class MediaHavenClient:
             )
         else:
             # Execute the request - Form
-            files = files if files else {}
+            files_to_send = files if files else {}
             response = self._execute_request(
-                **dict(method="POST", url=resource_url, files=files, data=form_data)
+                **dict(
+                    method="POST", url=resource_url, files=files_to_send, data=form_data
+                )
             )
 
         # Raise appropriate exception if HTTPError occurred


### PR DESCRIPTION
Add two high-level functions, allowing for upload via file URL:
 - A single file with sidecar metadata
 - A MediaHaven complex 2.0 zip file without sidecar metadata

A "single file" is basically an essence with (sidecar) metadata. The "complex file" (=zip) doesn't need sidecar metadata as the metadata is specified in the METS.xml.