### PR TITLE
MHPY-26 Support passing includeDeleted to the records endpoint

### DIFF
--- a/mediahaven/resources/records.py
+++ b/mediahaven/resources/records.py
@@ -37,13 +37,24 @@ class Records(BaseResource):
         )
 
     def get(
-        self, record_id: str, accept_format=DEFAULT_ACCEPT_FORMAT
+        self,
+        record_id: str,
+        accept_format=DEFAULT_ACCEPT_FORMAT,
+        include_deleted=False,
+        **query_params,
     ) -> MediaHavenSingleObject:
         """Get a single record.
 
         Args:
             record_id: It can either be a MediaObjectId, FragmentId or RecordId.
             accept_format: The "Accept" request header.
+            include_deleted: If true, also return the record if it has been
+                logically deleted.
+            **query_params: Further optional query parameters:
+                query_params["fields"]: (array) Currently only supports "Exif"
+                    value.  If provided, Exif field is added to Technical-family.
+                    If the record has record structure Data, the information is
+                    obtained from the original representation.
 
         Returns:
             A single record.
@@ -51,6 +62,8 @@ class Records(BaseResource):
         response = self.mh_client._get(
             self._construct_path(record_id),
             accept_format,
+            includeDeleted=str(include_deleted).lower(),
+            **query_params,
         )
         return MediaHavenSingleObjectCreator.create_object(response, accept_format)
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -21,7 +21,24 @@ class TestRecords:
 
         # Assert
         mh_client_mock._get.assert_called_once_with(
-            f"{records.name}/{record_id}", AcceptFormat.JSON
+            f"{records.name}/{record_id}", AcceptFormat.JSON, includeDeleted="false"
+        )
+        object_creator_mock.create_object.assert_called_once_with(
+            mh_client_mock._get(), AcceptFormat.JSON
+        )
+
+    @patch("mediahaven.resources.records.MediaHavenSingleObjectCreator")
+    def test_get_with_include_deleted(self, object_creator_mock, records: Records):
+        # Arrange
+        record_id = "1"
+        mh_client_mock = records.mh_client
+
+        # Act
+        records.get(record_id, include_deleted=True)
+
+        # Assert
+        mh_client_mock._get.assert_called_once_with(
+            f"{records.name}/{record_id}", AcceptFormat.JSON, includeDeleted="true"
         )
         object_creator_mock.create_object.assert_called_once_with(
             mh_client_mock._get(), AcceptFormat.JSON


### PR DESCRIPTION
This boolean query parameter can be used to return items when they have been logically deleted.  On the off-chance that capitalization matters and to make it a little more ergonomic, we specifically handle the parameter and convert it to a string value ourselves.  Additionally we allow passing other optional query parameters.

I'm not sure if the extra parameters need to be passed to the `MediaHavenSingleObjectCreator.create_object)` method as well (analogous to the search method)?