### PR TITLE
MHPY-11 Fix invalid refresh token

### DIFF
--- a/mediahaven/mediahaven.py
+++ b/mediahaven/mediahaven.py
@@ -10,6 +10,7 @@ from requests.models import Response
 from oauthlib.oauth2.rfc6749.errors import (
     TokenExpiredError,
     InvalidGrantError,
+    InvalidClientIdError,
 )
 from urllib.parse import urlencode, urljoin, quote as urlquote
 
@@ -102,10 +103,10 @@ class MediaHavenClient:
                 self.grant.refresh_token()
                 session = self.grant._get_session()
                 response = session.request(**kwargs)
-            except InvalidGrantError:
+            except (InvalidGrantError, InvalidClientIdError) as e:
                 # Refresh token invalid / revoked
                 # Depending on grant, different action is needed
-                raise RefreshTokenError
+                raise RefreshTokenError from e
             else:
                 return response
         except RequestException:


### PR DESCRIPTION
When the token is expired, a new one is requested given the refresh token. If that renewal process fails because the refresh token is revoked or expired, it should raise a RefreshTokenError by catching the underlying oauthlib error.

In theory it should catch a InvalidGrantError (as defined in rfc6749):

"The provided authorization grant (e.g. authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."

In practice an InvalidClientIdError is raised, which seems to be something else: "Invalid client_id parameter value."

It is not entirely clear if this is because of oauthlib, oauthlib-requests, the actual MediaHaven response or a combination.

As a solution, catch an InvalidClientIdError as well, and raise a RefreshTokenError.